### PR TITLE
Update canary.ipynb

### DIFF
--- a/examples/istio/canary_update/canary.ipynb
+++ b/examples/istio/canary_update/canary.ipynb
@@ -566,9 +566,8 @@
     }
    ],
    "source": [
-    "!helm install ../../../helm-charts/seldon-core-loadtesting --name loadtest  \\\n",
+    "!helm install  loadtest stable/locust \\\n",
     "    --namespace seldon \\\n",
-    "    --repo https://storage.googleapis.com/seldon-charts \\\n",
     "    --set locust.script=mnist_rest_locust.py \\\n",
     "    --set locust.host=http://{ISTIO_GATEWAY} \\\n",
     "    --set rest.pathPrefix=/seldon/seldon/mnist-classifier \\\n",


### PR DESCRIPTION
Remove --name for helmv3 and get error  Error: chart "loadtest" not found in https://storage.googleapis.com/seldon-charts repository